### PR TITLE
Remove error

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,12 +22,13 @@ module.exports = function (html, options, callback) {
         });
     });
     batch.end(function (err, results) {
-        var stylesData = results.shift(),
-            css;
-
         if (err) {
             return callback(err);
         }
+
+        var stylesData = results.shift(),
+            css;
+
         results.forEach(function (content) {
             stylesData.css.push(content);
         });


### PR DESCRIPTION
```
******\node_modules\extract-css\index.js:25
  var stylesData = results.shift(),
                           ^

TypeError: Cannot read property 'shift' of undefined
```
